### PR TITLE
Add tests for openai-gpt, roberta-base, and albert-base-v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,13 @@ Make sure you have python>=3.8; run the following command:
 pip install git+https://github.com/lxuechen/private-transformers.git
 ```
 
+To check the package is installed properly, be sure to run the test suite (requires pytest and a GPU) via the following
+command:
+
+```bash
+pytest -s tests
+```
+
 ## Usage
 
 ### Basic usage
@@ -127,7 +134,8 @@ should be sufficient to get things started. Detailed instructions are in the rea
 
 Not all models in the Hugging Face library are supported. The main additional work here is to
 
-1. support per-example gradients for bespoke modules (e.g., [T5LayerNorm](https://huggingface.co/transformers/_modules/transformers/modeling_t5.html)), and
+1. support per-example gradients for bespoke modules
+   (e.g., [T5LayerNorm](https://huggingface.co/transformers/_modules/transformers/modeling_t5.html)), and
 2. ensure `position_ids` are repeated.
 
 We plan to support more models in the future if there's such a need. Feel free to open an issue if you may want to try

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ of [Hugging Face transformers](https://huggingface.co/transformers/).
 Make sure you have python>=3.8; run the following command:
 
 ```bash
-pip install git+ssh://git@github.com/lxuechen/private-transformers.git
+pip install git+https://github.com/lxuechen/private-transformers.git
 ```
 
 ## Usage

--- a/tests/test_privacy_engine.py
+++ b/tests/test_privacy_engine.py
@@ -5,6 +5,8 @@ You will need a GPU to run this!
 
 python tests/test_privacy_engine.py
 pytest -s tests
+
+TODO: Ghost clipping currently fails when there's gradient for the padding token. This is minor but a nice-to-fix.
 """
 import contextlib
 import copy
@@ -64,7 +66,7 @@ def _prepare_inputs(batch: dict):
 
 @pytest.mark.parametrize(
     'ghost_clipping,model_name_or_path',
-    itertools.product([True, False], ['roberta-base', 'bert-base-cased', ])
+    itertools.product([True, False], ['roberta-base', 'bert-base-cased'])
 )
 def test_bert(ghost_clipping: bool, model_name_or_path: str):
     gc.collect()
@@ -85,8 +87,10 @@ def test_bert(ghost_clipping: bool, model_name_or_path: str):
         attention_probs_dropout_prob=0.,
         hidden_dropout_prob=0.,
         return_dict=True,
-        padding_idx=-1,  # This is important for ghost clipping to work, since roberta-base default to 1.
+        padding_idx=-1,
+        pad_token_id=-1,  # This is important for ghost clipping to work, since roberta-base default to 1.
     )
+
     model = transformers.AutoModelForSequenceClassification.from_pretrained(model_name_or_path, config=config)
     model.requires_grad_(True).train()
 


### PR DESCRIPTION
These tests reveal that the norm computation in ghost clipping might be slightly off when there's padding tokens. This should be put on the timeline. 